### PR TITLE
security: CWE-532: Remove debug logging that exposes bearer tokens — VC-53751

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func main() {
 		keyResourceID: pluginArgs.InitOptions.KeyResourceID,
 	}
 
-	resp, err := handler.Dispatch(os.Stdout, os.Stdin, pluginArgs, signerVerifier)
+	_, err = handler.Dispatch(os.Stdout, os.Stdin, pluginArgs, signerVerifier)
 	if err != nil {
 		// Dispatch() will have already called WriteResponse() with the error.
 		panic(err)

--- a/main.go
+++ b/main.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/sigstore/sigstore/pkg/signature/kms/cliplugin/handler"
 )
 
@@ -28,7 +27,6 @@ const expectedProtocolVersion = "v1"
 
 func main() {
 	// we log to stderr, not stdout. stdout is reserved for the plugin return value.
-	spew.Fdump(os.Stderr, os.Args)
 	if protocolVersion := os.Args[1]; protocolVersion != expectedProtocolVersion {
 		err := fmt.Errorf("expected protocol version: %s, got %s", expectedProtocolVersion, protocolVersion)
 		handler.WriteErrorResponse(os.Stdout, err)
@@ -40,7 +38,6 @@ func main() {
 		handler.WriteErrorResponse(os.Stdout, err)
 		panic(err)
 	}
-	spew.Fdump(os.Stderr, pluginArgs)
 
 	signerVerifier := &VenafiSignerVerifier{
 		hashFunc:      pluginArgs.InitOptions.HashFunc,
@@ -52,5 +49,4 @@ func main() {
 		// Dispatch() will have already called WriteResponse() with the error.
 		panic(err)
 	}
-	spew.Fdump(os.Stderr, resp)
 }


### PR DESCRIPTION
## Summary

Removed debug logging statements using `spew.Fdump` that could expose sensitive authentication data including bearer tokens to stderr.

## Finding

**CWE-532: Insertion of Sensitive Information into Log File**
- Severity: High
- Location: `main.go`

The plugin was using `spew.Fdump` to dump complete data structures (`os.Args`, `pluginArgs`, and `resp`) to stderr for debugging. These structures can contain sensitive authentication tokens and credentials that should not be logged.

## Remediation

Removed all `spew.Fdump` debug logging calls:
- Removed `spew.Fdump(os.Stderr, os.Args)` on line 31
- Removed `spew.Fdump(os.Stderr, pluginArgs)` on line 43  
- Removed `spew.Fdump(os.Stderr, resp)` on line 55
- Removed unused `spew` import

This prevents bearer tokens and other sensitive data from being written to log output.

## Verification

Changes are minimal and focused solely on removing the debug logging statements that expose sensitive data. No functional logic was modified.