### PR TITLE
security: CWE-347: Ed25519 empty message bypass — VC-53750

### DIFF
--- a/venafi.go
+++ b/venafi.go
@@ -179,6 +179,9 @@ func (i VenafiSignerVerifier) VerifySignature(signature io.Reader, message io.Re
 			return fmt.Errorf("failed verification")
 		}
 	case ed25519.PublicKey:
+		if len(msg) == 0 {
+			return fmt.Errorf("message cannot be empty for Ed25519 verification")
+		}
 		if !ed25519.Verify(publicKey, msg, sig) {
 			return fmt.Errorf("failed verification")
 		}


### PR DESCRIPTION
## Summary

Fixes CWE-347 Ed25519 signature verification bypass via empty message by adding explicit validation to reject empty messages before verification.

## Finding

**CWE-347**: Improper Verification of Cryptographic Signature  
**Severity**: High

The Ed25519 signature verification in `VerifySignature()` did not validate that the message was non-empty before calling `ed25519.Verify()`. This could allow an attacker to bypass signature verification by providing an empty message, as Ed25519 verification with an empty message may produce unexpected results.

## Remediation

Added a check in the `VerifySignature` method (line 182-184 of venafi.go) to explicitly reject empty messages for Ed25519 signature verification:

```go
case ed25519.PublicKey:
    if len(msg) == 0 {
        return fmt.Errorf("message cannot be empty for Ed25519 verification")
    }
    if !ed25519.Verify(publicKey, msg, sig) {
        return fmt.Errorf("failed verification")
    }
```

This ensures that signature verification fails early and explicitly when an empty message is provided, preventing the vulnerability.

## Verification

- Changed 1 file: `venafi.go`
- Added 3 lines validating message length before Ed25519 verification
- Fix is minimal and focused on the specific vulnerability

**Note**: Build and test validation encountered environmental issues (GOROOT configuration) unrelated to this security fix.

---
🤖 Generated by Project Logos Pattern-C security remediation